### PR TITLE
Ensure git is installed before trying to use git module

### DIFF
--- a/provisioning/roles/backup/tasks/main.yml
+++ b/provisioning/roles/backup/tasks/main.yml
@@ -7,6 +7,11 @@
     - duplicity
     - mailutils
 
+- name: Ensure git is installed
+  apt:
+    pkg: git
+    update_cache: yes
+
 - name: Clone database-backup repository
   git:
     repo: https://github.com/openaustralia/database-backup.git


### PR DESCRIPTION
I had provisioning fail on a fresh box because it got to this and git
wasn't installed already.

I’ve added the update_cache here so that it is always works properly.