### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file is used to define code owners for this repository.
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @openaustralia/team-infrastructure


### PR DESCRIPTION
## Relevant issue(s)
- N/A

## What does this do?
This pull request adds a `CODEOWNERS` file to the repository, assigning ownership of all files to the `@openaustralia/team-infrastructure` team. This helps clarify responsibility for code reviews and approvals. 

* Added a `.github/CODEOWNERS` file that assigns all repository files to the `@openaustralia/team-infrastructure` team.

## Why was this needed?
- Ensures that a code review is required before changes are deployed

## Implementation/Deploy Steps (Optional)
- Nil - PR just needs to be approved (which I will be doing)

## Notes to reviewer (Optional)
