### PR TITLE
Add extra GitHub users and update ansible setup to run on modern ubuntu LTS and python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ config/newrelic.yml
 coverage
 .vagrant
 
+# Keep in sync with provisioning/requirements.yml and provision_production.sh
 provisioning/roles/newrelic.newrelic-infra
 provisioning/roles/rvm.ruby
 provisioning/roles/geerlingguy.certbot

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ docker compose exec web rake
 
 We use [Vagrant](https://www.vagrantup.com/) and [Ansible](http://docs.ansible.com/) to automatically set up a fresh
 server with everything you need to run Cuttlefish. It's a fairly complicated affair as Cuttlefish does have quite a few
-moving
-parts but all of this is with the purpose of making it easier for the developer sending mail.
+moving parts but all of this is with the purpose of making it easier for the developer sending mail.
 
 These instructions are specifically for installing the server at https://cuttlefish.oaf.org.au.
 
-Currently the setup requires a relatively old version of Ansible (2.5.0) using Python 2.7.
+Previously, the control node setup required a relatively old version of Ansible (2.5.0) using Python 2.7.
+This is being updated.
 
 ### To install to a local test virtual machine
 
@@ -160,7 +160,7 @@ bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:
    used in the deploy. The encrypted variables are at `provisioning/roles/cuttlefish-app/vars/main.yml`.
 
 10. To provision the server for the first time you will need to supply the root password you chose in step 5. On
-    subsequent deploys you won't need this. To supply this password run 
+    subsequent deploys you won't need this. To supply this password run
 
     ./provision_production.sh --ask-pass
 
@@ -169,9 +169,10 @@ bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:
     [VAR=value] ./provision_production.sh [--check [--diff]]
 
 ENV Variables:
-  * `TAGS` - comma separated tags to restrict playbook to those tags
-  * `SKIP_TAGS` - comma separated tags to skip
-  * `START_AT_TASK` - task name to start from
+
+* `TAGS` - comma separated tags to restrict playbook to those tags
+* `SKIP_TAGS` - comma separated tags to skip
+* `START_AT_TASK` - task name to start from
 
 11. Update the server name in `config/deploy.rb`
 
@@ -206,6 +207,19 @@ Some further things to ensure things work smoothly
 3. Set up reverse DNS. In the Linode Manager under "Remote Access" click "Reverse DNS" then for the hostname put in "
    cuttlefish.oaf.org.au" and follow the instructions. This step is necessary in order to be able to sign up to
    receive [Feedback loop emails](https://en.wikipedia.org/wiki/Feedback_loop_%28email%29).
+
+### Clobbering provisioning artefacts
+
+To clobber the venv dir (`.ansible`), and remove the roles that are dynamically downloaded and listed in `.gitignore`,
+run
+
+    ./provision_production.sh clobber
+
+You should run this if you change:
+
+* `provisioning/requirements.txt` - python3 packages
+* `provisioning/requirements.yml` - ansible roles downloaded rather than committed to git
+* The version of python3 installed on your system
 
 ## Deploying to production
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:
 ./provision_production.sh
 ```
 
+Extra options
+  * TAGS - comma separated tags to restrict playbook to those tags
+  * SKIP_TAGS - comma separated tags to skip
+  * START_AT_TASK - task name to start from
+
 11. Update the server name in `config/deploy.rb`
 
 12. Deploy the application. As this is the first deploy it will take quite a while (5 mins or so). Further deploys will

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 Cuttlefish is a lovely, easy to set up transactional email server
 
-Sending a few emails from your app is easy. Sending lots becomes painful. There are so many hidden gotchas. Do your emails get delivered? Are you being considered a spammer? What about all those bounced emails?
+Sending a few emails from your app is easy. Sending lots becomes painful. There are so many hidden gotchas. Do your
+emails get delivered? Are you being considered a spammer? What about all those bounced emails?
 
 Let's make sending lots of emails fun again!
 
@@ -30,7 +31,9 @@ And without the hidden dangers of vendor lock in of commercial transactional ema
 * Postfix, which you know and trust, handles email delivery
 * Open source, so no vendor lock in.
 
-Cuttlefish is in beta. It's been used in production by [OpenAustralia Foundation](http://www.openaustraliafoundation.org.au)'s projects for many years and sends over a million emails per month.
+Cuttlefish is in beta. It's been used in production
+by [OpenAustralia Foundation](http://www.openaustraliafoundation.org.au)'s projects for many years and sends over a
+million emails per month.
 
 ## Screenshots
 
@@ -44,6 +47,7 @@ Cuttlefish is in beta. It's been used in production by [OpenAustralia Foundation
 * Incoming email
 
 ## Dependencies
+
 Ruby, PostgresQL, Redis (2.4 or greater), Postfix
 
 Also you need the following libraries:
@@ -57,17 +61,20 @@ Setting up a local development environment with all the correct dependencies and
 moving parts is now very straightforward by using [Docker](https://www.docker.com/).
 
 To start with:
+
 ```
 docker compose run web bundle exec rake db:create db:schema:load
 ```
 
-Now add some example seed data. This will also create a site admin with email "joy@smart-unlimited.com" and password "password". You'll need these details later to sign in. Skip this step if you don't want seed data.
+Now add some example seed data. This will also create a site admin with email "joy@smart-unlimited.com" and password "
+password". You'll need these details later to sign in. Skip this step if you don't want seed data.
 
 ```
 docker compose run web bundle exec rake db:seed
 ```
 
 Then
+
 ```
 docker compose up
 ```
@@ -79,7 +86,8 @@ When its stops spitting output to the console point your web browser at
 
 http://localhost:3000
 
-If you've used the `db:seed` task to populate the development database you can now log in using the email "joy@smart-unlimited.com" with the password "password".
+If you've used the `db:seed` task to populate the development database you can now log in using the email "
+joy@smart-unlimited.com" with the password "password".
 
 For development all mail sent out by Cuttlefish will actually go to mailcatcher.
 To see the mailcatcher mail:
@@ -87,13 +95,16 @@ To see the mailcatcher mail:
 http://localhost:1080
 
 To run the tests (do that from another window):
+
 ```
 docker compose exec web rake
 ```
 
 ## To install:
 
-We use [Vagrant](https://www.vagrantup.com/) and [Ansible](http://docs.ansible.com/) to automatically set up a fresh server with everything you need to run Cuttlefish. It's a fairly complicated affair as Cuttlefish does have quite a few moving
+We use [Vagrant](https://www.vagrantup.com/) and [Ansible](http://docs.ansible.com/) to automatically set up a fresh
+server with everything you need to run Cuttlefish. It's a fairly complicated affair as Cuttlefish does have quite a few
+moving
 parts but all of this is with the purpose of making it easier for the developer sending mail.
 
 These instructions are specifically for installing the server at https://cuttlefish.oaf.org.au.
@@ -102,19 +113,26 @@ Currently the setup requires a relatively old version of Ansible (2.5.0) using P
 
 ### To install to a local test virtual machine
 
-1. Create a file `~/.cuttlefish_ansible_vault_pass.txt` which contains the password for encrypting the secret values used in the deploy. The encrypted variables are at `provisioning/roles/cuttlefish-app/vars/main.yml`.
+1. Create a file `~/.cuttlefish_ansible_vault_pass.txt` which contains the password for encrypting the secret values
+   used in the deploy. The encrypted variables are at `provisioning/roles/cuttlefish-app/vars/main.yml`.
 
-2. Download base box and build virtual machine with everything needed for Cuttlefish. This will take a while (at least 30 mins or so)
+2. Download base box and build virtual machine with everything needed for Cuttlefish. This will take a while (at least
+   30 mins or so)
+
 ```
 vagrant up
 ```
 
-3. Deploy the application. As this is the first deploy it will take quite a while (5 mins or so). Further deploys will be much quicker. We're using the `--set-before local_deploy=true` flag to deploy to your local test virtual machine instead of production.
+3. Deploy the application. As this is the first deploy it will take quite a while (5 mins or so). Further deploys will
+   be much quicker. We're using the `--set-before local_deploy=true` flag to deploy to your local test virtual machine
+   instead of production.
+
 ```
 bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:export foreman:start
 ```
 
 4. Add to your local `/etc/hosts` file
+
 ```
 127.0.0.1       cuttlefish.oaf.org.au
 ```
@@ -131,15 +149,19 @@ bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:
 
 4. Select your new Linode in the dashboard
 
-5. Click "Deploy a Linux Distribution". Choose "Ubuntu 16.04 LTS" and choose a root password. Leave everything as default.
+5. Click "Deploy a Linux Distribution". Choose "Ubuntu 16.04 LTS" and choose a root password. Leave everything as
+   default.
 
 6. Click "Boot" and wait for it to start up
 
 8. Update `provisioning/hosts` with the name of your server (e.g. li123-45.members.linode.com)
 
-9. Create a file `~/.cuttlefish_ansible_vault_pass.txt` which contains the password for encrypting the secret values used in the deploy. The encrypted variables are at `provisioning/roles/cuttlefish-app/vars/main.yml`.
+9. Create a file `~/.cuttlefish_ansible_vault_pass.txt` which contains the password for encrypting the secret values
+   used in the deploy. The encrypted variables are at `provisioning/roles/cuttlefish-app/vars/main.yml`.
 
-10. To provision the server for the first time you will need to supply the root password you chose in step 5. On subsequent deploys you won't need this. To supply this password edit the `./provision_production.sh` script and temporily add the `--ask-pass` argument to the last command, then run the script:
+10. To provision the server for the first time you will need to supply the root password you chose in step 5. On
+    subsequent deploys you won't need this. To supply this password edit the `./provision_production.sh` script and
+    temporily add the `--ask-pass` argument to the last command, then run the script:
 
 ```
 ./provision_production.sh
@@ -147,7 +169,9 @@ bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:
 
 11. Update the server name in `config/deploy.rb`
 
-12. Deploy the application. As this is the first deploy it will take quite a while (5 mins or so). Further deploys will be much quicker
+12. Deploy the application. As this is the first deploy it will take quite a while (5 mins or so). Further deploys will
+    be much quicker
+
 ```
 cap deploy:setup
 cap deploy:cold
@@ -165,13 +189,17 @@ At this point you should have a basic working setup. You should be able to send 
 
 Some further things to ensure things work smoothly
 
-1. Add DNS TXT record for cuttlefish.oaf.org.au with "v=spf1 ip4:your.server.ip4.address ip6:your.server.ip6.address -all"
+1. Add DNS TXT record for cuttlefish.oaf.org.au with "v=spf1 ip4:your.server.ip4.address ip6:your.server.ip6.address
+   -all"
 
-2. Set up incoming email for cuttlefish.oaf.org.au (In OpenAustralia Foundation's case using Google Apps for domain). Add addresses contact@cuttlefish.oaf.org.au, bounces@cuttlefish.oaf.org.au and sender@cuttlefish.oaf.org.au
+2. Set up incoming email for cuttlefish.oaf.org.au (In OpenAustralia Foundation's case using Google Apps for domain).
+   Add addresses contact@cuttlefish.oaf.org.au, bounces@cuttlefish.oaf.org.au and sender@cuttlefish.oaf.org.au
 
 2. Ensure that the devise email address is set to contact@cuttlefish.oaf.org.au
 
-3. Set up reverse DNS. In the Linode Manager under "Remote Access" click "Reverse DNS" then for the hostname put in "cuttlefish.oaf.org.au" and follow the instructions. This step is necessary in order to be able to sign up to receive [Feedback loop emails](https://en.wikipedia.org/wiki/Feedback_loop_%28email%29).
+3. Set up reverse DNS. In the Linode Manager under "Remote Access" click "Reverse DNS" then for the hostname put in "
+   cuttlefish.oaf.org.au" and follow the instructions. This step is necessary in order to be able to sign up to
+   receive [Feedback loop emails](https://en.wikipedia.org/wiki/Feedback_loop_%28email%29).
 
 ## Deploying to production
 
@@ -179,25 +207,31 @@ One gotcha is that we're still on Capistrano 2 which doesn't apply database migr
 by default on deploys.
 
 For normal deploys
+
 ```
 cap deploy
 ```
 
 To rollback a failed deploy
+
 ```
 cap deploy:rollback
 ```
 
 To deploy and run the migrations
+
 ```
 cap deploy:migrations
 ```
 
 ## Screenshots
+
 Done some development work which updates the look of the main pages? To update the screenshots
+
 ```
 bundle exec rspec spec/features/screenshot_feature.rb
 ```
+
 Then commit the results
 
 ## How to contribute

--- a/README.md
+++ b/README.md
@@ -160,19 +160,18 @@ bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:
    used in the deploy. The encrypted variables are at `provisioning/roles/cuttlefish-app/vars/main.yml`.
 
 10. To provision the server for the first time you will need to supply the root password you chose in step 5. On
-    subsequent deploys you won't need this. To supply this password edit the `./provision_production.sh` script and
-    temporily add the `--ask-pass` argument to the last command, then run the script:
+    subsequent deploys you won't need this. To supply this password run 
 
-    Add `--check` to do a dry run and `--diff` as well to see the changes.
+    ./provision_production.sh --ask-pass
 
-```
-[VAR=value] ./provision_production.sh [--check [--diff]]
-```
+    # Yopu can also add `--check` to do a dry run and `--diff` as well to see the changes.
 
-Extra options
-  * TAGS - comma separated tags to restrict playbook to those tags
-  * SKIP_TAGS - comma separated tags to skip
-  * START_AT_TASK - task name to start from
+    [VAR=value] ./provision_production.sh [--check [--diff]]
+
+ENV Variables:
+  * `TAGS` - comma separated tags to restrict playbook to those tags
+  * `SKIP_TAGS` - comma separated tags to skip
+  * `START_AT_TASK` - task name to start from
 
 11. Update the server name in `config/deploy.rb`
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ bundle exec cap --set-before local_deploy=true deploy:setup deploy:cold foreman:
     subsequent deploys you won't need this. To supply this password edit the `./provision_production.sh` script and
     temporily add the `--ask-pass` argument to the last command, then run the script:
 
+    Add `--check` to do a dry run and `--diff` as well to see the changes.
+
 ```
-./provision_production.sh
+[VAR=value] ./provision_production.sh [--check [--diff]]
 ```
 
 Extra options

--- a/provision_production.sh
+++ b/provision_production.sh
@@ -1,5 +1,58 @@
 #!/bin/bash
 
+# Error handler to show what went wrong
+error_handler() {
+    echo "ERROR: Command failed at line $1" >&2
+    echo "Failed command: $2" >&2
+    exit 1
+}
+
+# Set up error trapping
+set -e
+set -E
+trap 'error_handler ${LINENO} "$BASH_COMMAND"' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# as per .gitignore's recommendation
+VENV_DIR="$SCRIPT_DIR/.ansible"
+PROVISIONING_DIR="$SCRIPT_DIR/provisioning"
+
+case "$1" in
+clobber)
+  echo "Clobbering .ansible virtualenv and imported roles ..."
+  rm -rf "${VENV_DIR}" \
+  "${PROVISIONING_DIR}/roles/newrelic.newrelic-infra" \
+  "${PROVISIONING_DIR}/roles/rvm.ruby" \
+  "${PROVISIONING_DIR}/roles/geerlingguy.certbot" \
+  "${PROVISIONING_DIR}/roles/DavidWittman.redis" \
+  "${PROVISIONING_DIR}/roles/ANXS.postgresql" \
+  "${PROVISIONING_DIR}/roles/abtris.nginx-passenger" \
+  "${PROVISIONING_DIR}/roles/nickhammond.logrotate"
+  exit
+  ;;
+esac
+# Create and activate virtual environment if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Creating Python virtual environment in .ansible/"
+    python3 -m venv "$VENV_DIR"
+fi
+
+# Activate virtual environment
+source "$VENV_DIR/bin/activate"
+
+# Install/upgrade ansible if needed
+if ! pip show ansible &>/dev/null || [ "$VENV_DIR/bin/ansible-playbook" -ot "$PROVISIONING_DIR/requirements.txt" ]; then
+    echo "Installing Ansible from requirements.txt"
+    pip install -r "$PROVISIONING_DIR/requirements.txt"
+fi
+
+# Install roles if needed
+if [ ! -d "$PROVISIONING_DIR/roles/DavidWittman.redis" ]; then
+    echo "Installing Ansible roles"
+    ansible-galaxy install -r "$PROVISIONING_DIR/requirements.yml" -p "$PROVISIONING_DIR/roles"
+fi
+
+# Build extra arguments
 extra_args=''
 
 case "$TAGS" in
@@ -21,4 +74,4 @@ case "$START_AT_TASK" in
     ;;
 esac
 
-ansible-playbook -i provisioning/hosts provisioning/playbook.yml $extra_args "$@"
+ansible-playbook -i "$PROVISIONING_DIR/hosts" "$PROVISIONING_DIR/playbook.yml" $extra_args "$@"

--- a/provision_production.sh
+++ b/provision_production.sh
@@ -74,4 +74,5 @@ case "$START_AT_TASK" in
     ;;
 esac
 
+set -x
 ansible-playbook -i "$PROVISIONING_DIR/hosts" "$PROVISIONING_DIR/playbook.yml" $extra_args "$@"

--- a/provision_production.sh
+++ b/provision_production.sh
@@ -1,2 +1,24 @@
 #!/bin/bash
-ansible-playbook -i provisioning/hosts provisioning/playbook.yml
+
+extra_args=''
+
+case "$TAGS" in
+?*)
+    extra_args="$extra_args --tags=facts,$TAGS"
+    ;;
+esac
+
+case "$SKIP_TAGS" in
+?*)
+    extra_args="$extra_args --skip-tags=$SKIP_TAGS"
+    ;;
+esac
+
+case "$START_AT_TASK" in
+?*)
+    sat=$(echo "*${START_AT_TASK}*" | sed 's/ /*/g')
+    extra_args="$extra_args --start-at-task=$sat"
+    ;;
+esac
+
+ansible-playbook -i provisioning/hosts provisioning/playbook.yml $extra_args "$@"

--- a/provisioning/group_vars/all
+++ b/provisioning/group_vars/all
@@ -1,0 +1,11 @@
+# group_vars/all
+---
+github_users:
+  - 'br3nda'
+  - 'henare'
+  - 'ianheggie-oaf'
+  - 'jamezpolley'
+  - 'mlandauer'
+  - 'simonzippy'
+  - 'benrfairless'
+

--- a/provisioning/hosts
+++ b/provisioning/hosts
@@ -1,1 +1,2 @@
- li743-35.members.linode.com
+# Ready for CDN
+cuttlefish.oaf.org.au ansible_host=23.239.22.35

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -2,12 +2,14 @@
 - hosts: all
   become: true
   gather_facts: False
+  tags: ['python']
   tasks:
   - name: install python 2 (or python 3 on Ubuntu 20.04)
     raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal) || apt install -y python-is-python3
     changed_when: False
 
 - hosts: all
+  tags: ['verify']
   pre_tasks:
     - name: Verify Ansible meets version requirements.
       assert:

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -19,5 +19,5 @@
   become: true
   #user: root
   roles:
-    - { role: deploy-user, github_users: ['mlandauer', 'henare', 'jamezpolley', 'ianheggie-oaf'], tags: ['deploy-user'] }
+    - { role: deploy-user, tags: ['deploy-user'] }
     - { role: cuttlefish-app, tags: ['cuttlefish-app'] }

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -19,5 +19,5 @@
   become: true
   #user: root
   roles:
-    - {role: deploy-user, github_users: ['mlandauer', 'henare', 'jamezpolley']}
-    - cuttlefish-app
+    - { role: deploy-user, github_users: ['mlandauer', 'henare', 'jamezpolley', 'ianheggie-oaf'], tags: ['deploy-user'] }
+    - { role: cuttlefish-app, tags: ['cuttlefish-app'] }

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -11,13 +11,14 @@
   pre_tasks:
     - name: Verify Ansible meets version requirements.
       assert:
-        that: ansible_version.major == 2 and ansible_version.minor == 8
+        # was 2.8
+        that: "ansible_version.major == 2 and ansible_version.minor == 15"
         msg: >
-          "This currently works with Ansible 2.8"
+          "This currently works with Ansible core 2.15 not {{ansible_version.major}}.{{ansible_version.minor}}"
 
 - hosts: all
   become: true
   #user: root
   roles:
-    - { role: deploy-user, tags: ['deploy-user'] }
-    - { role: cuttlefish-app, tags: ['cuttlefish-app'] }
+    - { role: deploy-user, tags: ['deploy_user'] }
+    - { role: cuttlefish-app, tags: ['cuttlefish_app'] }

--- a/provisioning/requirements.txt
+++ b/provisioning/requirements.txt
@@ -1,3 +1,5 @@
+# Automatically installed by provision_production.sh
+#
 # Install the correct version of ansible (best to do in a virtual
 # environment) with:
 # cd provisioning

--- a/provisioning/requirements.txt
+++ b/provisioning/requirements.txt
@@ -3,4 +3,19 @@
 # cd provisioning
 # pip install -r requirements.txt
 
-ansible==2.8.17
+# Ansible 8.7.0 uses ansible-core 2.15.13,
+# Control node: Python 3.9 to 3.11 supported (NOT 3.12 officially, but works in practice)
+#   Otherwise mac OS/X users would need to upgrade their python using homebrew etc
+# Target: Python 2.7, Python 3.5 to 3.11
+# * cuttlefish has, as of 31 Jan 2026: Python 2.7.18 and 3.8.10
+# ansible 8.7 has the ansible-galaxy SSL bug fix which is needed for python 3.12
+# (was ansible==2.8.17, tried 2.9.27, 5.10.0, 6.7.0)
+ansible==8.7.0
+
+# Consider:
+# Ansible 9.11.0 uses ansible-core 2.16.14
+# Control node: Python 3.10-3.12 officially supported
+# Target node: Python 2.7, Python 3.6-3.12
+# * cuttlefish has, as of 31 Jan 2026: Python 2.7.18 and 3.8.10
+# (was ansible==2.8.17, tried 2.9.27, 5.10.0, 6.7.0, 8.7.0)
+# ansible==9.11.0

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -13,6 +13,7 @@
 - src: geerlingguy.certbot
   version: 3.0.0
 
+# Upgrade before changing ansible version as it uses the old include statement rather than include_tasks
 - src: DavidWittman.redis
   version: 1.2.8
 

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,3 +1,5 @@
+# Automatically installed by provision_production.sh
+#
 # Install required roles with
 # cd provisioning
 # ansible-galaxy install -r requirements.yml -p roles

--- a/provisioning/roles/cuttlefish-app/tasks/main.yml
+++ b/provisioning/roles/cuttlefish-app/tasks/main.yml
@@ -1,36 +1,46 @@
 ---
+
+# NOTE: provisioning/roles/cuttlefish-app/meta/main.yml has prerequisites that run first
+# and does a fair bit of work, not just establish common libraries to call!
+
 - name: Remove apache2
   apt:
     name: apache2
     state: absent
+  tags: ['nginx', 'apt']
 
 - name: Install nginx
   apt:
     pkg:
       - nginx
     state: present
+  tags: ['nginx', 'apt']
 
 - name: Add key for passenger
   apt_key:
     url: http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xAC40B2F7
     state: present
+  tags: ['nginx']
 
 - name: Apt via https
   apt:
     name: apt-transport-https
     state: present
+  tags: ['nginx', 'passenger', 'apt']
 
 - name: Apt add passenger to list
   apt_repository:
     repo: 'deb https://oss-binaries.phusionpassenger.com/apt/passenger {{ansible_distribution_release}} main'
     state: present
     update_cache: yes
+  tags: ['nginx', 'passenger', 'apt']
 
 - name: Install passenger
   apt:
     pkg:
       - libnginx-mod-http-passenger
     state: present
+  tags: ['nginx', 'passenger', 'apt']
 
 - name: Ensure that deploy owns /srv/www
   file:
@@ -38,6 +48,7 @@
     group: deploy
     path: /srv/www
     state: directory
+  tags: ['app']
 
 - name: Ensure that /srv/www/shared exists
   file:
@@ -45,18 +56,22 @@
     owner: deploy
     group: deploy
     state: directory
+  tags: ['app']
 
 - name: Ensure git is installed
   apt:
     pkg: git
+  tags: ['apt']
 
 - name: Add postgresql apt signing key
   apt_key:
     url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+  tags: ['postgresql', 'apt']
 
 - name: Add postgresql apt repository
   apt_repository:
     repo: deb http://apt.postgresql.org/pub/repos/apt focal-pgdg main
+  tags: ['postgresql', 'apt']
 
 - name: Install postgresql 13
   apt:
@@ -65,6 +80,7 @@
       - postgresql-client-13
       - libpq-dev
     update_cache: yes
+  tags: ['postgresql', 'apt']
 
 - name: Trust local database access
   template:
@@ -72,6 +88,7 @@
     dest: /etc/postgresql/13/main/pg_hba.conf
     owner: postgres
     group: postgres
+  tags: ['postgresql', 'apt']
 
 # We want the restart to happen immediately so that postgresl will be available
 # for later tasks
@@ -79,17 +96,20 @@
   service:
     name: postgresql
     state: restarted
+  tags: ['postgresql', 'apt']
 
 - name: Make sure the right version of postgresql starts at boot
   systemd:
     state: started
     name: postgresql@13-main
+  tags: ['postgresql', 'apt']
 
 # Installing via bash so that rvm is used. Otherwise would install gems for default system ruby
 - name: Install bundler gem
   command: bash -lc "gem install bundler --version 2.3.26"
   args:
     creates: "/usr/local/lib/rvm/gems/ruby-3.0.6/gems/bundler-2.3.26"
+  tags: ['ruby', 'rvm']
 
 - name: Install package dependencies that allow gem native extensions to be built
   apt:
@@ -98,6 +118,7 @@
       - g++
       # Required for encryption in eventmachine
       - libssl-dev
+  tags: ['ruby', 'apt']
 
 - name: Ensure that .env exists
   template:
@@ -106,6 +127,7 @@
     owner: deploy
     group: deploy
   notify: nginx restart
+  tags: ['app']
   # TODO: Should also restart the log daemon
 
 - name: Directory to hold configs for ssl on tracking links
@@ -114,6 +136,7 @@
     owner: deploy
     group: deploy
     state: directory
+  tags: ['nginx']
 
 - name: Directory to hold nginx configs for ssl on tracking links
   file:
@@ -121,12 +144,14 @@
     owner: deploy
     group: deploy
     state: directory
+  tags: ['nginx']
 
 - name: Generate the overall nginx config
   template:
     src: nginx.conf
     dest: /etc/nginx/nginx.conf
   notify: nginx reload
+  tags: ['nginx']
 
 - name: Generate the nginx config for the app
   template:
@@ -136,14 +161,17 @@
     group: root
     mode: "644"
   notify: nginx reload
+  tags: ['nginx']
 
 - name: Install python module requirement for ansible creating postgresql db
   apt:
     pkg: python3-psycopg2
+  tags: ['postgresql', 'apt']
 
 - name: Create cuttlefish postgresql database
   postgresql_db:
     name: cuttlefish
+  tags: ['postgresql']
 
 - name: Create cuttlefish posgresql role
   postgresql_user:
@@ -151,11 +179,13 @@
     name: cuttlefish
     password: "{{ db_password }}"
     encrypted: yes
+  tags: ['postgresql']
 
 - name: Create postgresql role for root so it can do backups
   postgresql_user:
     name: root
     role_attr_flags: SUPERUSER
+  tags: ['postgresql']
 
 - name: Copy over database configuration for application
   template:
@@ -164,6 +194,7 @@
     owner: deploy
     group: deploy
   notify: nginx restart
+  tags: ['app']
 
 - name: Allow deploy user to export foreman script
   lineinfile:
@@ -171,6 +202,7 @@
     state: present
     line: 'deploy ALL=(ALL) NOPASSWD: /usr/local/lib/rvm/wrappers/default/bundle exec foreman export systemd /etc/systemd/system -a cuttlefish -u deploy -l /srv/www/shared/log -f Procfile.production'
     validate: 'visudo -cf %s'
+  tags: ['app']
 
 - name: Allow deploy user to reload systemd daemon after changing config
   lineinfile:
@@ -178,6 +210,7 @@
     state: present
     line: 'deploy ALL=(ALL) NOPASSWD: /bin/systemctl daemon-reload'
     validate: 'visudo -cf %s'
+  tags: ['app']
 
 - name: Allow deploy user to start cuttlefish service
   lineinfile:
@@ -185,6 +218,7 @@
     state: present
     line: 'deploy ALL=(ALL) NOPASSWD: /bin/systemctl start cuttlefish.target'
     validate: 'visudo -cf %s'
+  tags: ['app']
 
 - name: Allow deploy user to stop cuttlefish service
   lineinfile:
@@ -192,6 +226,7 @@
     state: present
     line: 'deploy ALL=(ALL) NOPASSWD: /bin/systemctl stop cuttlefish.target'
     validate: 'visudo -cf %s'
+  tags: ['app']
 
 - name: Allow deploy user to restart cuttlefish service
   lineinfile:
@@ -199,6 +234,7 @@
     state: present
     line: 'deploy ALL=(ALL) NOPASSWD: /bin/systemctl restart cuttlefish.target'
     validate: 'visudo -cf %s'
+  tags: ['app']
 
 - name: Allow deploy user to check the nginx configuration
   lineinfile:
@@ -206,6 +242,7 @@
     state: present
     line: 'deploy ALL=(ALL) NOPASSWD: /usr/sbin/service nginx configtest'
     validate: 'visudo -cf %s'
+  tags: ['app']
 
 - name: Allow deploy user to reload the nginx configuration
   lineinfile:
@@ -213,17 +250,20 @@
     state: present
     line: 'deploy ALL=(ALL) NOPASSWD: /usr/sbin/service nginx reload'
     validate: 'visudo -cf %s'
+  tags: ['app']
 
 - name: Allow deploy to read some log files (different from admin group)
   user:
     name: deploy
     groups: adm
     append: yes
+  tags: ['app']
 
 - name: Install certbot
   apt:
     pkg: certbot
     update_cache: yes
+  tags: ['nginx']
 
 # We need this for the next step (which needs to happen before certbot runs
 # the first time)
@@ -232,6 +272,7 @@
     path: /etc/letsencrypt/renewal-hooks/deploy
     state: directory
     mode: "0755"
+  tags: ['cuttlefish']
 
 # Note that we're doing this before the certificate is generated because we want
 # the new certificate copied across immediately. But the slight hassle is we
@@ -242,6 +283,7 @@
     src: copy-cuttlefish-daemon-certs.sh
     dest: /etc/letsencrypt/renewal-hooks/deploy/copy-cuttlefish-daemon-certs
     mode: 755
+  tags: ['cuttlefish']
 
 - name: Install certificate using certbot
   include_role:
@@ -257,7 +299,7 @@
         domains:
           - cuttlefish.oaf.org.au
           - cuttlefish.io
-
+  tags: ['cuttlefish']
 
 - name: Daily archiving and deny list removal tasks
   cron:
@@ -266,3 +308,4 @@
     user: deploy
     minute: "0"
     hour: "12"
+  tags: ['cuttlefish']

--- a/provisioning/roles/cuttlefish-backup/tasks/main.yml
+++ b/provisioning/roles/cuttlefish-backup/tasks/main.yml
@@ -5,24 +5,29 @@
     pkg:
       - duplicity
       - mailutils
+  tags: [ 'apt', 'backup' ]
 
 - name: Ensure git is installed
   apt:
     pkg: git
     update_cache: yes
+  tags: [ 'apt', 'backup' ]
 
 - name: Clone database-backup repository
   git:
     repo: https://github.com/openaustralia/database-backup.git
     dest: /root/database-backup
+  tags: [ 'backup' ]
 
 - name: Copy database-backup configuration
   template:
     src: duplicity-backup.conf
     dest: /root/database-backup/duplicity-backup.conf
+  tags: [ 'backup' ]
 
 - name: Configure backup cronjob
   cron:
     name: backup
     job: /root/database-backup/database-backup.sh
     special_time: daily
+  tags: [ 'backup' ]

--- a/provisioning/roles/cuttlefish-postfix/meta/main.yml
+++ b/provisioning/roles/cuttlefish-postfix/meta/main.yml
@@ -122,6 +122,7 @@ galaxy_info:
   #- web
 dependencies:
   - role: nickhammond.logrotate
+    tags: ['logrotate', 'cuttlefish']
     logrotate_scripts:
       - name: mail
         path: /var/log/mail/mail.log

--- a/provisioning/roles/cuttlefish-postfix/tasks/main.yml
+++ b/provisioning/roles/cuttlefish-postfix/tasks/main.yml
@@ -1,30 +1,35 @@
 ---
 - name: Install postfix
   apt: pkg=postfix
+  tags: ['postfix']
 
 - name: Configure postfix logs to go to their own directory
   copy:
     src: 50-default.conf
     dest: /etc/rsyslog.d
   notify: restart rsyslog
+  tags: ['postfix']
 
 - name: Check postfix opportunistic TLS
   command: "postconf -h smtp_tls_security_level"
   changed_when: False
   register: postfix_smtp_tls_security_level
   check_mode: no
+  tags: ['postfix']
 
 - name: Enable postfix opportunistic TLS for encrypted outbound email
   command: postconf -e smtp_tls_security_level=may
   when: postfix_smtp_tls_security_level.stdout != "may"
   notify:
     - restart postfix
+  tags: ['postfix']
 
 - name: Check protocols used for sending emails
   command: "postconf -h inet_protocols"
   changed_when: False
   register: postfix_inet_protocols
   check_mode: no
+  tags: ['postfix']
 
 # See https://www.linode.com/community/questions/19723/changing-ipv6-address-to-new-64-subnet
 # This is a workaround for the problem where the /64 IPv6 block that we're using
@@ -35,3 +40,4 @@
   when: postfix_inet_protocols.stdout != "ipv4"
   notify:
     - restart postfix
+  tags: ['postfix']


### PR DESCRIPTION
**Why is this required?**

Ben asked for me to deploy his ssh keys to cuttlefish, and I found the cuttlefish provisioning would not run on my Ubuntu LTS 24.04.3 LTS (Noble) system that has python 3.12 by default (released April 25, 2024)

**What does this do?**

* Enable use of ed2519 ssh keys with capistrano as I use them
*  Add provisioning helper ENV vars so i can select deploy_user role only
* Update documentation
* Adds github_users: br3nda, ianheggie-oaf, simonzippy, benrfairless to existing users mlandauer, henare, jamezpolley (to match morph's list)
* Moves github user list to group_vars/all so its always available
* Adds tags to everything so you can filter what provisioning is done (reduces risk, because its focused on what you want to achieve)
* Update provision_production.sh to setup and use venv, and download roles as needed to eliminate manual steps
* Update inventory as linode no longer publishes an alternative name for linodes when reverse dns is set up

**Installation:**

Already run to add ben. Just merge to main.
